### PR TITLE
Fix "IssueFilter#accept(issue, chain)" broken chained calls

### DIFF
--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
@@ -109,6 +109,9 @@ public class IssuesChecker implements IssueFilter {
 
   @Override
   public boolean accept(FilterableIssue issue, IssueFilterChain chain) {
+    if (!chain.accept(issue)) {
+      return false;
+    }
     if (disabled) {
       return true;
     }


### PR DESCRIPTION
When several IssueFilter extensions exist in a picocontainer, the order they are injected into:
sonar-enterprise / sonar-scanner-engine / org.sonar.scanner.issue.IssueFilters
depends on picocontainer logic. (see [sonar-scanner-engine - org/sonar/scanner/issue/IssueFilters.java#L37](https://github.com/SonarSource/sonarqube/blob/38fe6f4b9ecc3fe0db208770288bdad66eca251c/sonar-scanner-engine/src/main/java/org/sonar/scanner/issue/IssueFilters.java#L37))

With orchestrator version <= 3.30.0.2630, there was always the "sonar-reset-data-plugin" added to support "Orchestrator#resetData()".
And by an incredible chance, it influences picocontainer to always order of IssueFilter in the ruling of SonarJava:
1) sonar-java PostAnalysisIssueFilter
2) sonar-lits-plugin IssuesChecker

Unfortunately, with orchestrator version >= 3.31.0.2646, there is not anymore the "sonar-reset-data-plugin".
And thanks to Murphy's law, it influences picocontainer to always order IssueFilter in the ruling of SonarJava:
1) sonar-lits-plugin IssuesChecker
2) sonar-java PostAnalysisIssueFilter

And because sonar-lits-plugin was ignoring IssueFilterChain, it made the ruling of SonarJava fails.
(see [ORCH-448 Remove method Orchestrator.resetData()](https://github.com/SonarSource/orchestrator/commit/0b1d0a6068cccb3612b802553ab6ea21eeb8d202#diff-fa1f3525554b02b1c9474dd0d35710a0a3acf185b9f5f72a7fded0520befb4a0L215))