### PR TITLE
LITS-28 Property names should have prefix "sonar.lits."

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/lits/LitsTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/lits/LitsTest.java
@@ -149,9 +149,9 @@ public class LitsTest {
       .setProjectKey(projectKey)
       .setProjectVersion("1")
       .setSourceDirs("src")
-      .setProperty("dump.old", new File(projectDir, dumpOld).toString())
-      .setProperty("dump.new", output.toString())
-      .setProperty("lits.differences", temporaryFolder.newFile("differences").getAbsolutePath())
+      .setProperty("sonar.lits.dump.old", new File(projectDir, dumpOld).toString())
+      .setProperty("sonar.lits.dump.new", output.toString())
+      .setProperty("sonar.lits.differences", temporaryFolder.newFile("differences").getAbsolutePath())
       .setProperty("sonar.cpd.skip", "true");
   }
 

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.sonar.api.batch.rule.ActiveRule;
@@ -75,9 +76,9 @@ public class IssuesChecker implements IssueFilter {
 
   // must be public for SQ picocontainer
   public IssuesChecker(Configuration settings, ActiveRules activerules) {
-    oldDumpFile = getFile(settings, LITSPlugin.OLD_DUMP_PROPERTY);
-    newDumpFile = getFile(settings, LITSPlugin.NEW_DUMP_PROPERTY);
-    differencesFile = getFile(settings, LITSPlugin.DIFFERENCES_PROPERTY);
+    oldDumpFile = getFile(settings, LITSPlugin.OLD_DUMP_PROPERTY, LITSPlugin.DEPRECATED_OLD_DUMP_PROPERTY);
+    newDumpFile = getFile(settings, LITSPlugin.NEW_DUMP_PROPERTY, LITSPlugin.DEPRECATED_NEW_DUMP_PROPERTY);
+    differencesFile = getFile(settings, LITSPlugin.DIFFERENCES_PROPERTY, LITSPlugin.DEPRECATED_DIFFERENCES_PROPERTY);
     for (ActiveRule activeRule : activerules.findAll()) {
       if (!activeRule.severity().equals(Severity.INFO)) {
         RuleKey ruleKey = activeRule.ruleKey();
@@ -185,9 +186,19 @@ public class IssuesChecker implements IssueFilter {
     }
   }
 
-  private static File getFile(Configuration settings, String property) {
-    String path = settings.get(property).orElseThrow(() -> MessageException.of("Missing property '" + property + "'"));
-    File file = new File(path);
+  private static File getFile(Configuration settings, String property, String deprecatedProperty) {
+    Optional<String> path = settings.get(property);
+    if (!path.isPresent()) {
+      // The setting with the new property name was not found: remove the LITS-specific prefix and try with the old property name.
+      path = settings.get(deprecatedProperty);
+      if (path.isPresent()) {
+        LOG.warn("Property '" + deprecatedProperty + "' is deprecated, use '" + property + "' instead");
+      } else {
+        throw MessageException.of("Missing property '" + property + "'");
+      }
+    }
+
+    File file = new File(path.get());
     if (!file.isAbsolute()) {
       throw MessageException.of("Path must be absolute - check property '" + property + "'");
     }

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/LITSPlugin.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/LITSPlugin.java
@@ -27,11 +27,6 @@ public class LITSPlugin implements Plugin {
   static final String NEW_DUMP_PROPERTY = "sonar.lits.dump.new";
   static final String DIFFERENCES_PROPERTY = "sonar.lits.differences";
 
-  // These property names are deprecated, but kept from compatibility reasons
-  static final String DEPRECATED_OLD_DUMP_PROPERTY = "dump.old";
-  static final String DEPRECATED_NEW_DUMP_PROPERTY = "dump.new";
-  static final String DEPRECATED_DIFFERENCES_PROPERTY = "lits.differences";
-
   @Override
   public void define(Context context) {
     context.addExtensions(IssuesChecker.class, DumpPhase.class);

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/LITSPlugin.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/LITSPlugin.java
@@ -23,9 +23,14 @@ import org.sonar.api.Plugin;
 
 public class LITSPlugin implements Plugin {
 
-  static final String OLD_DUMP_PROPERTY = "dump.old";
-  static final String NEW_DUMP_PROPERTY = "dump.new";
-  static final String DIFFERENCES_PROPERTY = "lits.differences";
+  static final String OLD_DUMP_PROPERTY = "sonar.lits.dump.old";
+  static final String NEW_DUMP_PROPERTY = "sonar.lits.dump.new";
+  static final String DIFFERENCES_PROPERTY = "sonar.lits.differences";
+
+  // These property names are deprecated, but kept from compatibility reasons
+  static final String DEPRECATED_OLD_DUMP_PROPERTY = "dump.old";
+  static final String DEPRECATED_NEW_DUMP_PROPERTY = "dump.new";
+  static final String DEPRECATED_DIFFERENCES_PROPERTY = "lits.differences";
 
   @Override
   public void define(Context context) {

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
@@ -20,6 +20,7 @@
 package com.sonarsource.lits;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,22 +76,6 @@ public class IssuesCheckerTest {
     thrown.expect(MessageException.class);
     thrown.expectMessage("Missing property 'sonar.lits.dump.old'");
     new IssuesChecker(settings, activeRules);
-  }
-
-  @Test
-  public void path_deprecated_property_name() {
-    MapSettings settings = new MapSettings();
-    settings.setProperty("dump.old", "/some/old/dump");
-    settings.setProperty("dump.new", "/some/new/dump");
-    settings.setProperty("lits.differences", "/some/diff/file");
-
-    new IssuesChecker(settings.asConfig(), activeRules);
-
-    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(
-      "Property 'dump.old' is deprecated, use 'sonar.lits.dump.old' instead",
-      "Property 'dump.new' is deprecated, use 'sonar.lits.dump.new' instead",
-      "Property 'lits.differences' is deprecated, use 'sonar.lits.differences' instead"
-    );
   }
 
   @Test
@@ -193,11 +178,13 @@ public class IssuesCheckerTest {
   }
 
   @Test
-  public void getPrevious_should_return_empty_list_when_no_output_directory() {
+  public void getPrevious_should_return_empty_list_when_no_output_directory() throws IOException {
+    String nonExistingPath = new File("file/does/not/exist").getCanonicalPath();
+
     MapSettings settings = new MapSettings();
-    settings.setProperty(LITSPlugin.OLD_DUMP_PROPERTY, "/file/does/not/exist");
-    settings.setProperty(LITSPlugin.NEW_DUMP_PROPERTY, "/file/does/not/exist");
-    settings.setProperty(LITSPlugin.DIFFERENCES_PROPERTY, "/file/does/not/exist");
+    settings.setProperty(LITSPlugin.OLD_DUMP_PROPERTY, nonExistingPath);
+    settings.setProperty(LITSPlugin.NEW_DUMP_PROPERTY, nonExistingPath);
+    settings.setProperty(LITSPlugin.DIFFERENCES_PROPERTY, nonExistingPath);
     checker = new IssuesChecker(settings.asConfig(), activeRules);
 
     Map previous = checker.getPrevious();

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
@@ -36,7 +36,6 @@ import org.sonar.api.scan.issue.filter.FilterableIssue;
 import org.sonar.api.scan.issue.filter.IssueFilterChain;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.log.LogTester;
-import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;


### PR DESCRIPTION
This PR adds the `sonar.lits` prefix to all property names used by lits:

- `dump.old` -> `sonar.lits.dump.old`
- `dump.new` -> `sonar.lits.dump.new`
- `lits.differences` -> `sonar.lits.differences`

This makes the property names more consistent with property names in other plugins and also solves some issues where certain scanners discard property names which do not start with `sonar.`.