### PR TITLE
LITS-33 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/lits/LitsTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/lits/LitsTest.java
@@ -144,6 +144,7 @@ public class LitsTest {
     orchestrator.getServer().provisionProject(projectKey, projectKey);
     orchestrator.getServer().associateProjectToQualityProfile(projectKey, "java", "profile");
     return SonarScanner.create(projectDir)
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey(projectKey)
       .setProjectVersion("1")
       .setSourceDirs("src")


### PR DESCRIPTION
On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.