### PR TITLE
Add check-sca workflow for validation

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -1,0 +1,16 @@
+name: Required SCA Check
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  verify-sca:
+    runs-on: github-ubuntu-latest-s  # Public repo with auth actions
+    name: Verify SCA
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: SonarSource/ci-github-actions/check-sca@v1

--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -14,3 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: SonarSource/ci-github-actions/check-sca@v1
+        with:
+          project-key: org.sonarsource.sonar-lits-plugin:lits


### PR DESCRIPTION
## Summary
- add a dedicated Required SCA Check workflow on pull_request and merge_group
- use SonarSource/ci-github-actions/check-sca@v1
- intentionally do not set project-key to validate auto-discovery behavior

## Why
This is to validate whether current red SCA status is due to check-sca resolving a different key than the one used by analysis.

## Follow-up
If key mismatch is confirmed, we can add explicit project-key in a follow-up.
