### PR TITLE
Set explicit check-sca project key metadata

### DIFF
--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,0 +1,2 @@
+check-sca:
+  project-key: org.sonarsource.sonar-lits-plugin:lits


### PR DESCRIPTION
## Summary
- add `.github/repo-metadata.yaml`
- set `check-sca.project-key` to `org.sonarsource.sonar-lits-plugin:lits`

## Why
`check-sca` key auto-discovery can resolve to `SonarSource_sonar-lits`, while the actual Sonar project key is `org.sonarsource.sonar-lits-plugin:lits`. Setting the project key explicitly makes the check query the correct project.

## Reference
- https://github.com/SonarSource/ci-github-actions/blob/master/README.md#manually-setting-the-project-key-for-the-check
