### PR TITLE
Restore DumpPhase inline comments

### DIFF
--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/DumpPhase.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/DumpPhase.java
@@ -56,6 +56,7 @@ public class DumpPhase implements ProjectSensor {
 
   @Override
   public void execute(SensorContext context) {
+    // disable IssueFilter
     checker.disabled = true;
     Set<InputDir> inputDirs = new HashSet<>();
     FileSystem fs = context.fileSystem();
@@ -76,10 +77,12 @@ public class DumpPhase implements ProjectSensor {
     if (!componentIssues.isEmpty()) {
       checker.disabled = true;
       for (IssueKey issueKey : checker.getByComponentKey(resource.key())) {
+        // missing issue => create
         checker.different = true;
         RuleKey ruleKey = RuleKey.parse(issueKey.ruleKey);
         ActiveRule activeRule = activeRules.find(ruleKey);
         if (activeRule == null) {
+          // rule not active => skip it
           checker.inactiveRule(issueKey.ruleKey);
           continue;
         }


### PR DESCRIPTION
Follow-up to #105.

## Summary
- restore the inline comments accidentally removed from `DumpPhase`
- keep the change limited to the missing comments Pavel pointed out

## Verification
- `mvn -pl sonar-lits-plugin test`
