### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/quality-cfamily-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Ownership update:**
  - Update `.github/CODEOWNERS` to assign ownership to the `@SonarSource/code-quality-core-languages-parsers-squad` team.

<sub>This will update automatically on new commits.</sub>