### PR TITLE
CLP-129 Normalize Jira automation workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Part of 
+<!-- 
+  Only for standalone PRs without Jira issue in the PR title: 
+    * Replace this comment with Epic ID to create a new Task in Jira
+    * Replace this comment with Issue ID to create a new Sub-Task in Jira
+    * Ignore or delete this note to create a new Task in Jira without a parent 
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Part of 
-<!-- 
-  Only for standalone PRs without Jira issue in the PR title: 
+<!--
+  Only for standalone PRs without Jira issue in the PR title:
     * Replace this comment with Epic ID to create a new Task in Jira
     * Replace this comment with Issue ID to create a new Sub-Task in Jira
-    * Ignore or delete this note to create a new Task in Jira without a parent 
+    * Ignore or delete this note to create a new Task in Jira without a parent
 -->

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -5,9 +5,9 @@ on:
     types: [closed]
 
 jobs:
-  PullRequestMerged_job:
-    name: Pull Request Merged
-    runs-on: github-ubuntu-latest-s
+  PullRequestClosed_job:
+    name: Pull Request Closed
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -26,10 +26,3 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
-
-  PR_Build_Cleanup:
-    runs-on: sonar-xs
-    permissions:
-      actions: write
-    steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -24,5 +24,12 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+  PR_Build_Cleanup:
+    runs-on: sonar-xs
+    permissions:
+      actions: write
+    steps:
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -13,7 +13,6 @@ jobs:
     # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.sender.type != 'Bot'
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -1,18 +1,19 @@
-name: Request review
+name: Pull Request Created
 
 on:
   pull_request:
-    types: ["review_requested"]
+    types: ["opened"]
 
 jobs:
-  RequestReview_job:
-    name: Request review
+  PullRequestCreated_job:
+    name: Pull Request Created
     runs-on: sonar-xs
     permissions:
       id-token: write
-    # For external PR, ticket should be moved manually
+    # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.sender.type != 'Bot'
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3
@@ -21,8 +22,9 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestCreated@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-project: LITS

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually


### PR DESCRIPTION
## Summary
- normalize Jira automation workflows to the agreed CLP-129 baseline
- align the four Jira workflow files on the common shape and `@v2` action references
- add or normalize the shared PR template where needed

## Testing
- not run (GitHub workflow configuration changes only)