### PR TITLE
LITS-41 Fix plugin build failures

### DIFF
--- a/sonar-lits-plugin/pom.xml
+++ b/sonar-lits-plugin/pom.xml
@@ -45,6 +45,12 @@
       <version>33.6.0-jre</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
       <version>1.3.2</version>

--- a/sonar-lits-plugin/pom.xml
+++ b/sonar-lits-plugin/pom.xml
@@ -35,16 +35,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.22.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>33.6.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
@@ -125,7 +115,7 @@
               <rules>
                 <requireFilesSize>
                   <maxsize>1000000</maxsize>
-                  <minsize>900000</minsize>
+                  <minsize>80000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Dump.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Dump.java
@@ -16,13 +16,9 @@
  */
 package com.sonarsource.lits;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.Multiset;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
-import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,12 +26,16 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 class Dump {
 
@@ -46,7 +46,7 @@ class Dump {
 
   static Map<String, Multiset<IssueKey>> load(File dir) {
     Map<String, Multiset<IssueKey>> result = new HashMap<>();
-    for (File file : FileUtils.listFiles(dir, new String[]{EXT}, false)) {
+    for (File file : listJsonFiles(dir.toPath())) {
       load(file, result);
     }
     return result;
@@ -60,7 +60,7 @@ class Dump {
     ) {
       json = (JSONObject) JSONValue.parse(in);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new UncheckedIOException(e);
     }
 
     String ruleKey = ruleKeyFromFileName(file.getName());
@@ -69,7 +69,7 @@ class Dump {
 
       Multiset<IssueKey> issues = result.get(componentKey);
       if (issues == null) {
-        issues = HashMultiset.create();
+        issues = Multiset.create();
         result.put(componentKey, issues);
       }
 
@@ -82,9 +82,9 @@ class Dump {
 
   static void save(List<IssueKey> issues, File dir) {
     try {
-      FileUtils.forceMkdir(dir);
+      Files.createDirectories(dir.toPath());
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new UncheckedIOException(e);
     }
 
     issues.sort(new IssueKeyComparator());
@@ -100,7 +100,7 @@ class Dump {
         try {
           out = new PrintStream(Files.newOutputStream(dir.toPath().resolve(ruleKeyToFileName(issueKey.ruleKey))), /* autoFlush: */ true, StandardCharsets.UTF_8.name());
         } catch (IOException e) {
-          throw Throwables.propagate(e);
+          throw new UncheckedIOException(e);
         }
         out.print("{");
         startComponent(out, issueKey.componentKey);
@@ -140,6 +140,19 @@ class Dump {
     endComponent(out);
     out.print("\n}\n");
     out.close();
+  }
+
+  private static List<File> listJsonFiles(Path dir) {
+    try (Stream<Path> paths = Files.list(dir)) {
+      List<File> files = new ArrayList<>();
+      paths
+        .filter(Files::isRegularFile)
+        .filter(path -> path.getFileName().toString().endsWith("." + EXT))
+        .forEach(path -> files.add(path.toFile()));
+      return files;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private static class IssueKeyComparator implements Comparator<IssueKey>, Serializable {

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Dump.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Dump.java
@@ -19,7 +19,6 @@ package com.sonarsource.lits;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import com.google.common.io.Closeables;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
@@ -140,7 +139,7 @@ class Dump {
   private static void endRule(PrintStream out) {
     endComponent(out);
     out.print("\n}\n");
-    Closeables.closeQuietly(out);
+    out.close();
   }
 
   private static class IssueKeyComparator implements Comparator<IssueKey>, Serializable {

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/DumpPhase.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/DumpPhase.java
@@ -16,8 +16,6 @@
  */
 package com.sonarsource.lits;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Multiset;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +69,6 @@ public class DumpPhase implements ProjectSensor {
     save();
   }
 
-  @VisibleForTesting
   private void createMissingIssues(SensorContext context, InputComponent resource) {
     Multiset<IssueKey> componentIssues = checker.getByComponentKey(resource.key());
     if (!componentIssues.isEmpty()) {
@@ -105,7 +102,6 @@ public class DumpPhase implements ProjectSensor {
     }
   }
 
-  @VisibleForTesting
   void save() {
     for (Map.Entry<String, Multiset<IssueKey>> entry : checker.getPrevious().entrySet()) {
       if (!entry.getValue().isEmpty()) {

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/IssuesChecker.java
@@ -16,22 +16,20 @@
  */
 package com.sonarsource.lits;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.Multiset;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.io.FileUtils;
+import java.util.stream.Collectors;
 import org.sonar.api.batch.rule.ActiveRule;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.config.Configuration;
@@ -87,7 +85,7 @@ public class IssuesChecker implements IssueFilter {
     if (previous == null) {
       if (!oldDumpFile.isDirectory()) {
         LOG.warn("Directory not found: {}", oldDumpFile);
-        previous = ImmutableMap.of();
+        previous = Collections.emptyMap();
       } else {
         LOG.info("Loading {}", oldDumpFile);
         previous = Dump.load(oldDumpFile);
@@ -99,7 +97,7 @@ public class IssuesChecker implements IssueFilter {
   Multiset<IssueKey> getByComponentKey(String componentKey) {
     Multiset<IssueKey> issueKeys = getPrevious().get(componentKey);
     if (issueKeys == null) {
-      issueKeys = ImmutableMultiset.of();
+      issueKeys = Multiset.empty();
     }
     return issueKeys;
   }
@@ -119,7 +117,9 @@ public class IssuesChecker implements IssueFilter {
     if (componentIssues.contains(issueKey)) {
       // old issue => no need to persist
       componentIssues.remove(issueKey);
-      Preconditions.checkState(Severity.INFO.equals(issue.severity()));
+      if (!Severity.INFO.equals(issue.severity())) {
+        throw new IllegalStateException();
+      }
       return false;
     } else {
       // new issue => persist
@@ -142,10 +142,20 @@ public class IssuesChecker implements IssueFilter {
   private static void forceDelete(File file) {
     if (file.exists()) {
       try {
-        FileUtils.forceDelete(file);
+        deleteRecursively(file.toPath());
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new UncheckedIOException(e);
       }
+    }
+  }
+
+  private static void deleteRecursively(Path path) throws IOException {
+    List<Path> paths;
+    try (java.util.stream.Stream<Path> stream = Files.walk(path)) {
+      paths = stream.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+    }
+    for (Path current : paths) {
+      Files.deleteIfExists(current);
     }
   }
 
@@ -161,21 +171,21 @@ public class IssuesChecker implements IssueFilter {
       LOG.info("No differences in issues");
     }
     if (!inactiveRules.isEmpty()) {
-      String message = "Inactive rules: " + Joiner.on(", ").join(inactiveRules);
+      String message = "Inactive rules: " + String.join(", ", inactiveRules);
       messages.add(message);
       exception = MessageException.of(message);
     }
     if (!missingResources.isEmpty()) {
-      String message = "Files listed in Expected directory were not analyzed: " + Joiner.on(", ").join(missingResources);
+      String message = "Files listed in Expected directory were not analyzed: " + String.join(", ", missingResources);
       messages.add(message);
       exception = MessageException.of(message);
     }
     forceDelete(differencesFile);
     try {
       differencesFile.createNewFile();
-      Files.write(differencesFile.toPath(), Joiner.on("\n").join(messages).getBytes(StandardCharsets.UTF_8));
+      Files.write(differencesFile.toPath(), String.join("\n", messages).getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new UncheckedIOException(e);
     }
     if (exception != null) {
       throw exception;

--- a/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Multiset.java
+++ b/sonar-lits-plugin/src/main/java/com/sonarsource/lits/Multiset.java
@@ -1,0 +1,89 @@
+/*
+ * Sonar LITS Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonarsource.lits;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class Multiset<E> implements Iterable<E> {
+
+  private final Map<E, Integer> counts = new LinkedHashMap<>();
+  private int size;
+
+  static <E> Multiset<E> create() {
+    return new Multiset<>();
+  }
+
+  static <E> Multiset<E> empty() {
+    return new Multiset<>();
+  }
+
+  void add(E element) {
+    counts.merge(element, 1, Integer::sum);
+    size++;
+  }
+
+  boolean contains(E element) {
+    return counts.containsKey(element);
+  }
+
+  boolean remove(E element) {
+    Integer count = counts.get(element);
+    if (count == null) {
+      return false;
+    }
+    if (count == 1) {
+      counts.remove(element);
+    } else {
+      counts.put(element, count - 1);
+    }
+    size--;
+    return true;
+  }
+
+  boolean isEmpty() {
+    return size == 0;
+  }
+
+  int size() {
+    return size;
+  }
+
+  void clear() {
+    counts.clear();
+    size = 0;
+  }
+
+  @Override
+  public Iterator<E> iterator() {
+    List<E> elements = new ArrayList<>(size);
+    for (Map.Entry<E, Integer> entry : counts.entrySet()) {
+      for (int i = 0; i < entry.getValue(); i++) {
+        elements.add(entry.getKey());
+      }
+    }
+    return elements.iterator();
+  }
+
+  @Override
+  public String toString() {
+    return counts.toString();
+  }
+}

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/DumpPhaseTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/DumpPhaseTest.java
@@ -16,9 +16,6 @@
  */
 package com.sonarsource.lits;
 
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.Multiset;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -82,7 +79,7 @@ public class DumpPhaseTest {
 
   @Test
   public void should_save_on_project() {
-    when(checker.getByComponentKey(anyString())).thenReturn(HashMultiset.<IssueKey>create());
+    when(checker.getByComponentKey(anyString())).thenReturn(Multiset.<IssueKey>create());
 
     decorator.save();
 
@@ -91,7 +88,7 @@ public class DumpPhaseTest {
 
   @Test
   public void should_report_missing_issues() {
-    Multiset<IssueKey> issues = HashMultiset.create();
+    Multiset<IssueKey> issues = Multiset.create();
     issues.add(new IssueKey("", "squid:S00103", null));
     issues.add(new IssueKey("", "squid:S00104", null));
     when(checker.getByComponentKey(anyString())).thenReturn(issues);
@@ -111,11 +108,11 @@ public class DumpPhaseTest {
   @Test
   public void should_report_missing_files() {
     Map<String, Multiset<IssueKey>> previous = new HashMap<>();
-    Multiset<IssueKey> issues = HashMultiset.create();
+    Multiset<IssueKey> issues = Multiset.create();
     issues.add(new IssueKey("", "squid:S00103", null));
     previous.put("missing", issues);
     when(checker.getPrevious()).thenReturn(previous);
-    when(checker.getByComponentKey(anyString())).thenReturn(ImmutableMultiset.<IssueKey>of());
+    when(checker.getByComponentKey(anyString())).thenReturn(Multiset.<IssueKey>empty());
 
     decorator.save();
 

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/DumpTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/DumpTest.java
@@ -16,8 +16,6 @@
  */
 package com.sonarsource.lits;
 
-import com.google.common.collect.Multiset;
-import com.google.common.io.Files;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -25,6 +23,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,7 +61,7 @@ public class DumpTest {
       .append("]\n")
       .append("}\n")
       .toString();
-    assertThat(Files.toString(new File(dir, "repoKey-ruleKey1.json"), StandardCharsets.UTF_8)).isEqualTo(expected);
+    assertThat(new String(Files.readAllBytes(new File(dir, "repoKey-ruleKey1.json").toPath()), StandardCharsets.UTF_8)).isEqualTo(expected);
     expected = new StringBuilder()
       .append("{\n")
       .append("\"componentKey1\": [\n")
@@ -71,7 +70,7 @@ public class DumpTest {
       .append("]\n")
       .append("}\n")
       .toString();
-    assertThat(Files.toString(new File(dir, "repoKey-ruleKey2.json"), StandardCharsets.UTF_8)).isEqualTo(expected);
+    assertThat(new String(Files.readAllBytes(new File(dir, "repoKey-ruleKey2.json").toPath()), StandardCharsets.UTF_8)).isEqualTo(expected);
     expected = new StringBuilder()
       .append("{\n")
       .append("\"componentKey1\": [\n")
@@ -79,7 +78,7 @@ public class DumpTest {
       .append("]\n")
       .append("}\n")
       .toString();
-    assertThat(Files.toString(new File(dir, "repoKey-rule-key3.json"), StandardCharsets.UTF_8)).isEqualTo(expected);
+    assertThat(new String(Files.readAllBytes(new File(dir, "repoKey-rule-key3.json").toPath()), StandardCharsets.UTF_8)).isEqualTo(expected);
 
     Map<String, Multiset<IssueKey>> dump = Dump.load(dir);
     System.out.println(dump);

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/IssuesCheckerTest.java
@@ -18,6 +18,8 @@ package com.sonarsource.lits;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -161,6 +163,18 @@ public class IssuesCheckerTest {
   }
 
   @Test
+  public void should_fail_when_previous_issue_is_not_info() {
+    FilterableIssue issue = mock(FilterableIssue.class);
+    when(issue.componentKey()).thenReturn("project:src/Example.java");
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "S00103"));
+    when(issue.line()).thenReturn(1);
+    when(issue.severity()).thenReturn("BLOCKER");
+
+    assertThrows(IllegalStateException.class, () ->
+      checker.accept(issue, chainReturnTrue));
+  }
+
+  @Test
   public void should_fail_when_inactive_rules() {
     checker.inactiveRule("squid:S00103");
     MessageException e = assertThrows(MessageException.class, () ->
@@ -193,6 +207,20 @@ public class IssuesCheckerTest {
       checker.save());
     assertThat(e.getMessage()).isEqualTo("Files listed in Expected directory were not analyzed: missing_resource");
     assertThat(output).exists();
+  }
+
+  @Test
+  public void should_delete_existing_output_and_difference_artifacts() throws Exception {
+    File nestedDirectory = new File(output, "nested");
+    assertThat(nestedDirectory.mkdirs()).isTrue();
+    Files.write(new File(nestedDirectory, "stale.txt").toPath(), "stale".getBytes(StandardCharsets.UTF_8));
+    Files.write(assertion.toPath(), "old".getBytes(StandardCharsets.UTF_8));
+
+    checker.save();
+
+    assertThat(output).doesNotExist();
+    assertThat(assertion).exists();
+    assertThat(Files.readAllBytes(assertion.toPath())).isEmpty();
   }
 
   @Test

--- a/sonar-lits-plugin/src/test/java/com/sonarsource/lits/MultisetTest.java
+++ b/sonar-lits-plugin/src/test/java/com/sonarsource/lits/MultisetTest.java
@@ -1,0 +1,53 @@
+/*
+ * Sonar LITS Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonarsource.lits;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class MultisetTest {
+
+  @Test
+  public void remove_should_return_false_for_missing_element() {
+    Multiset<String> multiset = Multiset.create();
+    multiset.add("value");
+
+    assertThat(multiset.remove("missing")).isFalse();
+    assertThat(multiset.isEmpty()).isFalse();
+    assertThat(multiset.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void remove_should_decrement_count_without_removing_entry() {
+    Multiset<String> multiset = Multiset.create();
+    multiset.add("value");
+    multiset.add("value");
+
+    assertThat(multiset.remove("value")).isTrue();
+
+    List<String> values = new ArrayList<>();
+    for (String value : multiset) {
+      values.add(value);
+    }
+
+    assertThat(values).containsExactly("value");
+    assertThat(multiset.size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
## Summary

- Add explicit `jsr305` as a `provided` dependency in `sonar-lits-plugin` so the legacy `javax.annotation` types compile again.
- Replace the invalid `Closeables.closeQuietly(out)` call with `out.close()`.
- Remove runtime `guava` and `commons-io` from the plugin by replacing them with a small local `Multiset` and JDK file APIs, which brings the shaded artifact back under the CI size gate.
- Adjust the plugin size lower bound to reflect the smaller runtime artifact and add focused unit tests for the new helper logic.

## Functional Impact

- Compared against `fba4916` (`master` on July 8, 2026 before the Renovate merges), there is no material functional regression in normal LITS plugin behavior.
- Observable differences are limited to I/O failure paths now throwing `UncheckedIOException` instead of the previous Guava or Commons wrappers, and the shipped plugin jar no longer shading `guava` or `commons-io` for unsupported consumers that might have relied on those bundled classes.
- Both the PR head and `fba4916` pass `mvn verify` locally.

## Verification

- `mvn verify`
- `mvn verify` on `fba4916`